### PR TITLE
Update API versions of Intel and K8s DRA

### DIFF
--- a/deployments/delayed/external/deployment.yaml
+++ b/deployments/delayed/external/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         source:
           resourceClaimName: ext-gpu-claim
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: ext-gpu-claim-params
@@ -39,13 +39,13 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: ext-gpu-claim
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: ext-gpu-claim-params

--- a/deployments/delayed/external/pod-external.yaml
+++ b/deployments/delayed/external/pod-external.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: gpu-params1
@@ -7,14 +7,14 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: gpu-claim1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: gpu-params1
 ---

--- a/deployments/delayed/external/pod-shared.yaml
+++ b/deployments/delayed/external/pod-shared.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: gpu-params2
@@ -7,14 +7,14 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: gpu-claim2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: gpu-params2
 ---

--- a/deployments/delayed/external/resourceclaim.yaml
+++ b/deployments/delayed/external/resourceclaim.yaml
@@ -1,5 +1,5 @@
 # standalone resource-claim with parameters without andy Pod consuming it
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: gpu-params0
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: gpu-claim0
@@ -17,6 +17,6 @@ spec:
   allocationMode: WaitForFirstConsumer
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: gpu-params0

--- a/deployments/delayed/inline/deployment.yaml
+++ b/deployments/delayed/inline/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-gpu-claim-params
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 640
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-gpu-claim-params
 ---

--- a/deployments/delayed/inline/pod-inline-multiple.yaml
+++ b/deployments/delayed/inline/pod-inline-multiple.yaml
@@ -1,5 +1,5 @@
 # two claim parameters, two containers with different inline resource-claims
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters-multiple1
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 128
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters-multiple2
@@ -19,7 +19,7 @@ spec:
   type: "gpu"
   memory: 128
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template1
@@ -31,11 +31,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim-parameters-multiple1
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template2
@@ -47,7 +47,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim-parameters-multiple2
 ---

--- a/deployments/delayed/inline/pod-inline-too-big.yaml
+++ b/deployments/delayed/inline/pod-inline-too-big.yaml
@@ -1,5 +1,5 @@
 # One inline resource claim, one pod, two containers. One container uses resource, one does not.
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters-too-big
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 2096
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template-too-big
@@ -21,7 +21,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim-parameters-too-big
 ---

--- a/deployments/delayed/inline/pod-inline.yaml
+++ b/deployments/delayed/inline/pod-inline.yaml
@@ -1,5 +1,5 @@
 # one claim parameter with half GPU memory, one Pod with two containers: with and without claim
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 512
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template
@@ -21,7 +21,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim-parameters
 ---

--- a/deployments/delayed/inline/pod-inline2.yaml
+++ b/deployments/delayed/inline/pod-inline2.yaml
@@ -1,5 +1,5 @@
 # one claim parameter with half GPU memory, one Pod with two containers: with and without claim
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim2-parameters
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 511
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim2-template
@@ -21,7 +21,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim2-parameters
 ---

--- a/deployments/delayed/inline/pod-inline3.yaml
+++ b/deployments/delayed/inline/pod-inline3.yaml
@@ -1,5 +1,5 @@
 # one claim parameter with little GPU memory, one Pod with two containers: with and without claim
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters3
@@ -35,6 +35,6 @@ spec:
         spec:
           resourceClassName: intel-gpu
           parametersRef:
-            apiGroup: gpu.dra.intel.com/v1alpha
+            apiGroup: gpu.resource.intel.com/v1alpha2
             kind: GpuClaimParameters
             name: inline-claim-parameters3

--- a/deployments/immediate/external/deployment.yaml
+++ b/deployments/immediate/external/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         source:
           resourceClaimName: ext-gpu-claim
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: ext-gpu-claim-params
@@ -39,7 +39,7 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: ext-gpu-claim
@@ -47,6 +47,6 @@ spec:
   resourceClassName: intel-gpu
   allocationMode: Immediate
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: ext-gpu-claim-params

--- a/deployments/immediate/external/pod-external.yaml
+++ b/deployments/immediate/external/pod-external.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: gpu-params1
@@ -7,7 +7,7 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: gpu-claim1
@@ -15,7 +15,7 @@ spec:
   resourceClassName: intel-gpu
   allocationMode: Immediate
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: gpu-params1
 ---

--- a/deployments/immediate/external/pod-shared.yaml
+++ b/deployments/immediate/external/pod-shared.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: gpu-params2
@@ -7,7 +7,7 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: gpu-claim2
@@ -15,7 +15,7 @@ spec:
   resourceClassName: intel-gpu
   allocationMode: Immediate
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: gpu-params2
 ---

--- a/deployments/immediate/external/resourceclaim.yaml
+++ b/deployments/immediate/external/resourceclaim.yaml
@@ -1,5 +1,5 @@
 # standalone resource-claim with parameters without andy Pod consuming it
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: gpu-params0
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: gpu-claim0
@@ -17,6 +17,6 @@ spec:
   allocationMode: Immediate
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: gpu-params0

--- a/deployments/immediate/inline/deployment.yaml
+++ b/deployments/immediate/inline/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-gpu-claim-params
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 640
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template
@@ -21,7 +21,7 @@ spec:
     allocationMode: Immediate
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-gpu-claim-params
 ---

--- a/deployments/immediate/inline/pod-inline-multiple.yaml
+++ b/deployments/immediate/inline/pod-inline-multiple.yaml
@@ -1,5 +1,5 @@
 # two claim parameters, two containers with different inline resource-claims
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters-multiple1
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 128
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters-multiple2
@@ -19,7 +19,7 @@ spec:
   type: "gpu"
   memory: 128
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template1
@@ -32,11 +32,11 @@ spec:
     resourceClassName: intel-gpu
     allocationMode: Immediate
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim-parameters-multiple1
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template2
@@ -49,7 +49,7 @@ spec:
     resourceClassName: intel-gpu
     allocationMode: Immediate
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim-parameters-multiple2
 ---

--- a/deployments/immediate/inline/pod-inline-too-big.yaml
+++ b/deployments/immediate/inline/pod-inline-too-big.yaml
@@ -1,5 +1,5 @@
 # One inline resource claim, one pod, two containers. One container uses resource, one does not.
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters-too-big
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 2096
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template-too-big
@@ -22,7 +22,7 @@ spec:
     resourceClassName: intel-gpu
     allocationMode: Immediate
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim-parameters-too-big
 ---

--- a/deployments/immediate/inline/pod-inline.yaml
+++ b/deployments/immediate/inline/pod-inline.yaml
@@ -1,5 +1,5 @@
 # one claim parameter with half GPU memory, one Pod with two containers: with and without claim
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 512
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim-template
@@ -22,7 +22,7 @@ spec:
     resourceClassName: intel-gpu
     allocationMode: Immediate
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim-parameters
 ---

--- a/deployments/immediate/inline/pod-inline2.yaml
+++ b/deployments/immediate/inline/pod-inline2.yaml
@@ -1,5 +1,5 @@
 # one claim parameter with half GPU memory, one Pod with two containers: with and without claim
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim2-parameters
@@ -9,7 +9,7 @@ spec:
   type: "gpu"
   memory: 511
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: test-inline-claim2-template
@@ -22,7 +22,7 @@ spec:
     resourceClassName: intel-gpu
     allocationMode: Immediate
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-claim2-parameters
 ---

--- a/deployments/immediate/inline/pod-inline3.yaml
+++ b/deployments/immediate/inline/pod-inline3.yaml
@@ -1,5 +1,5 @@
 # one claim parameter with little GPU memory, one Pod with two containers: with and without claim
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-claim-parameters3
@@ -36,6 +36,6 @@ spec:
           resourceClassName: intel-gpu
           allocationMode: Immediate
           parametersRef:
-            apiGroup: gpu.dra.intel.com/v1alpha
+            apiGroup: gpu.resource.intel.com/v1alpha2
             kind: GpuClaimParameters
             name: inline-claim-parameters3

--- a/deployments/tests/2pod-2external-2gpu-mem.yaml
+++ b/deployments/tests/2pod-2external-2gpu-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-2gpu-mem-1
@@ -7,18 +7,18 @@ spec:
   type: "gpu"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-2gpu-mem-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-2gpu-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-2gpu-mem-2
@@ -27,14 +27,14 @@ spec:
   type: "gpu"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-2gpu-mem-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-2gpu-mem-2
 ---

--- a/deployments/tests/2pod-2external-2gpu.yaml
+++ b/deployments/tests/2pod-2external-2gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-2gpu-1
@@ -6,18 +6,18 @@ spec:
   count: 2
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-2gpu-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-2gpu-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-2gpu-2
@@ -25,14 +25,14 @@ spec:
   count: 2
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-2gpu-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-2gpu-2
 ---

--- a/deployments/tests/2pod-2external-2vf-mem.yaml
+++ b/deployments/tests/2pod-2external-2vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-2vf-mem-1
@@ -7,18 +7,18 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-2vf-mem-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-2vf-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-2vf-mem-2
@@ -27,14 +27,14 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-2vf-mem-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-2vf-mem-2
 ---

--- a/deployments/tests/2pod-2external-2vf.yaml
+++ b/deployments/tests/2pod-2external-2vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-2vf-1
@@ -6,18 +6,18 @@ spec:
   count: 2
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-2vf-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-2vf-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-2vf-2
@@ -25,14 +25,14 @@ spec:
   count: 2
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-2vf-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-2vf-2
 ---

--- a/deployments/tests/2pod-2external-gpu-mem.yaml
+++ b/deployments/tests/2pod-2external-gpu-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-gpu-mem-1
@@ -7,18 +7,18 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-gpu-mem-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-gpu-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-gpu-mem-2
@@ -27,14 +27,14 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-gpu-mem-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-gpu-mem-2
 ---

--- a/deployments/tests/2pod-2external-gpu.yaml
+++ b/deployments/tests/2pod-2external-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-gpu-1
@@ -6,18 +6,18 @@ spec:
   count: 1
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-gpu-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-gpu-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-gpu-2
@@ -25,14 +25,14 @@ spec:
   count: 1
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-gpu-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-gpu-2
 ---

--- a/deployments/tests/2pod-2external-vf-mem.yaml
+++ b/deployments/tests/2pod-2external-vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-vf-mem-1
@@ -7,18 +7,18 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-vf-mem-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-vf-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-vf-mem-2
@@ -27,14 +27,14 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-vf-mem-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-vf-mem-2
 ---

--- a/deployments/tests/2pod-2external-vf.yaml
+++ b/deployments/tests/2pod-2external-vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-vf-1
@@ -6,18 +6,18 @@ spec:
   count: 1
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-vf-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-vf-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-2external-vf-2
@@ -25,14 +25,14 @@ spec:
   count: 1
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-2external-vf-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-2external-vf-2
 ---

--- a/deployments/tests/2pod-external-2vf-mem.yaml
+++ b/deployments/tests/2pod-external-2vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-external-2vf-mem
@@ -7,14 +7,14 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-external-2vf-mem
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-external-2vf-mem
 ---

--- a/deployments/tests/2pod-external-2vf.yaml
+++ b/deployments/tests/2pod-external-2vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-external-2vf
@@ -6,14 +6,14 @@ spec:
   count: 2
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-external-2vf
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-external-2vf
 ---

--- a/deployments/tests/2pod-external-vf-mem.yaml
+++ b/deployments/tests/2pod-external-vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-external-vf-mem
@@ -7,14 +7,14 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-external-vf-mem
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-external-vf-mem
 ---

--- a/deployments/tests/2pod-external-vf.yaml
+++ b/deployments/tests/2pod-external-vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-2pod-external-vf
@@ -6,14 +6,14 @@ spec:
   count: 1
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-2pod-external-vf
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-2pod-external-vf
 ---

--- a/deployments/tests/claim-external-vf-mem.yaml
+++ b/deployments/tests/claim-external-vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-claim-external-vf-mem
@@ -7,13 +7,13 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-claim-external-vf-mem
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-claim-external-vf-mem

--- a/deployments/tests/deployment-external-gpu.yaml
+++ b/deployments/tests/deployment-external-gpu.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-external-gpu-deployment
@@ -8,14 +8,14 @@ spec:
   type: "gpu"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-external-gpu-deployment
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-external-gpu-deployment
 ---

--- a/deployments/tests/deployment-inline-gpu.yaml
+++ b/deployments/tests/deployment-inline-gpu.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-gpu-deployment
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: inline-gpu-deployment
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-gpu-deployment
 ---

--- a/deployments/tests/deployment-inline-vf.yaml
+++ b/deployments/tests/deployment-inline-vf.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: inline-vf-deployment
@@ -8,7 +8,7 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: inline-vf-deployment
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: inline-vf-deployment
 ---

--- a/deployments/tests/immediate-pod-inline-vf.yaml
+++ b/deployments/tests/immediate-pod-inline-vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: immediate-pod-inline-vf
@@ -7,7 +7,7 @@ spec:
   count: 1
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: immediate-pod-inline-vf
@@ -20,7 +20,7 @@ spec:
     resourceClassName: intel-gpu
     allocationMode: Immediate
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: immediate-pod-inline-vf
 ---

--- a/deployments/tests/pod-2external-vf-mem.yaml
+++ b/deployments/tests/pod-2external-vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2external-vf-mem-1
@@ -7,18 +7,18 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-2external-vf-mem-1
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-2external-vf-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2external-vf-mem-2
@@ -27,14 +27,14 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-2external-vf-mem-2
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-2external-vf-mem-2
 ---

--- a/deployments/tests/pod-2inline-2gpu-mem.yaml
+++ b/deployments/tests/pod-2inline-2gpu-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-2gpu-mem-1
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-2gpu-mem-1
@@ -20,11 +20,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-2gpu-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-2gpu-mem-2
@@ -34,7 +34,7 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-2gpu-mem-2
@@ -46,7 +46,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-2gpu-mem-2
 ---

--- a/deployments/tests/pod-2inline-2gpu.yaml
+++ b/deployments/tests/pod-2inline-2gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-2gpu-1
@@ -7,7 +7,7 @@ spec:
   count: 2
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-2gpu-1
@@ -19,11 +19,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-2gpu-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-2gpu-2
@@ -32,7 +32,7 @@ spec:
   count: 2
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-2gpu-2
@@ -44,7 +44,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-2gpu-2
 ---

--- a/deployments/tests/pod-2inline-2vf-mem.yaml
+++ b/deployments/tests/pod-2inline-2vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-2vf-mem-1
@@ -8,7 +8,7 @@ spec:
   type: "vf"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-2vf-mem-1
@@ -20,11 +20,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-2vf-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-2vf-mem-2
@@ -34,7 +34,7 @@ spec:
   type: "vf"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-2vf-mem-2
@@ -46,7 +46,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-2vf-mem-2
 ---

--- a/deployments/tests/pod-2inline-2vf.yaml
+++ b/deployments/tests/pod-2inline-2vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-2vf-1
@@ -7,7 +7,7 @@ spec:
   count: 2
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-2vf-1
@@ -19,11 +19,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-2vf-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-2vf-2
@@ -32,7 +32,7 @@ spec:
   count: 2
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-2vf-2
@@ -44,7 +44,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-2vf-2
 ---

--- a/deployments/tests/pod-2inline-gpu-mem.yaml
+++ b/deployments/tests/pod-2inline-gpu-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-gpu-mem-1
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-gpu-mem-1
@@ -20,11 +20,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-gpu-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-gpu-mem-2
@@ -34,7 +34,7 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-gpu-mem-2
@@ -46,7 +46,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-gpu-mem-2
 ---

--- a/deployments/tests/pod-2inline-gpu.yaml
+++ b/deployments/tests/pod-2inline-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-gpu-1
@@ -7,7 +7,7 @@ spec:
   count: 1
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-gpu-1
@@ -19,11 +19,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-gpu-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-gpu-2
@@ -32,7 +32,7 @@ spec:
   count: 1
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-gpu-2
@@ -44,7 +44,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-gpu-2
 ---

--- a/deployments/tests/pod-2inline-mix-mem.yaml
+++ b/deployments/tests/pod-2inline-mix-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-mix-mem-1
@@ -8,7 +8,7 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-mix-mem-1
@@ -20,11 +20,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-mix-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-mix-mem-2
@@ -34,7 +34,7 @@ spec:
   type: "gpu"
   memory: 4096
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-mix-mem-2
@@ -46,7 +46,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-mix-mem-2
 ---

--- a/deployments/tests/pod-2inline-mix.yaml
+++ b/deployments/tests/pod-2inline-mix.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-mix-1
@@ -7,7 +7,7 @@ spec:
   count: 2
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-mix-1
@@ -19,11 +19,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-mix-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-mix-2
@@ -32,7 +32,7 @@ spec:
   count: 1
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-mix-2
@@ -44,7 +44,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-mix-2
 ---

--- a/deployments/tests/pod-2inline-vf-mem.yaml
+++ b/deployments/tests/pod-2inline-vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-vf-mem-1
@@ -8,7 +8,7 @@ spec:
   type: "vf"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-vf-mem-1
@@ -20,11 +20,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-vf-mem-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-vf-mem-2
@@ -34,7 +34,7 @@ spec:
   type: "vf"
   memory: 4096
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-vf-mem-2
@@ -46,7 +46,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-vf-mem-2
 ---

--- a/deployments/tests/pod-2inline-vf.yaml
+++ b/deployments/tests/pod-2inline-vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-vf-1
@@ -7,7 +7,7 @@ spec:
   count: 1
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-vf-1
@@ -19,11 +19,11 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-vf-1
 ---
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-2inline-vf-2
@@ -32,7 +32,7 @@ spec:
   count: 1
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-2inline-vf-2
@@ -44,7 +44,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-2inline-vf-2
 ---

--- a/deployments/tests/pod-external-2gpu-mem.yaml
+++ b/deployments/tests/pod-external-2gpu-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-external-2gpu-mem
@@ -7,14 +7,14 @@ spec:
   type: "gpu"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-external-2gpu-mem
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-external-2gpu-mem
 ---

--- a/deployments/tests/pod-external-2gpu.yaml
+++ b/deployments/tests/pod-external-2gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-external-2gpu
@@ -6,14 +6,14 @@ spec:
   count: 2
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-external-2gpu
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-external-2gpu
 ---

--- a/deployments/tests/pod-external-2vf-mem.yaml
+++ b/deployments/tests/pod-external-2vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-external-2vf-mem
@@ -7,14 +7,14 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-external-2vf-mem
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-external-2vf-mem
 ---

--- a/deployments/tests/pod-external-2vf.yaml
+++ b/deployments/tests/pod-external-2vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-external-2vf
@@ -6,14 +6,14 @@ spec:
   count: 2
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-external-2vf
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-external-2vf
 ---

--- a/deployments/tests/pod-external-gpu-mem.yaml
+++ b/deployments/tests/pod-external-gpu-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-external-gpu-mem
@@ -7,14 +7,14 @@ spec:
   type: "gpu"
   memory: 256
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-external-gpu-mem
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-external-gpu-mem
 ---

--- a/deployments/tests/pod-external-gpu.yaml
+++ b/deployments/tests/pod-external-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-external-gpu
@@ -6,14 +6,14 @@ spec:
   count: 1
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-external-gpu
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-external-gpu
 ---

--- a/deployments/tests/pod-external-vf-mem.yaml
+++ b/deployments/tests/pod-external-vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-external-vf-mem
@@ -7,14 +7,14 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-external-vf-mem
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-external-vf-mem
 ---

--- a/deployments/tests/pod-external-vf.yaml
+++ b/deployments/tests/pod-external-vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-external-vf
@@ -6,14 +6,14 @@ spec:
   count: 1
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaim
 metadata:
   name: delayed-pod-external-vf
 spec:
   resourceClassName: intel-gpu
   parametersRef:
-    apiGroup: gpu.dra.intel.com/v1alpha
+    apiGroup: gpu.resource.intel.com/v1alpha2
     kind: GpuClaimParameters
     name: delayed-pod-external-vf
 ---

--- a/deployments/tests/pod-inline-2gpu-2.yaml
+++ b/deployments/tests/pod-inline-2gpu-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-2gpu-2
@@ -7,7 +7,7 @@ spec:
   count: 2
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-2gpu-2
@@ -19,7 +19,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-2gpu-2
 ---

--- a/deployments/tests/pod-inline-2gpu-mem-2.yaml
+++ b/deployments/tests/pod-inline-2gpu-mem-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-2gpu-mem-2
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-2gpu-mem-2
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-2gpu-mem-2
 ---

--- a/deployments/tests/pod-inline-2gpu-mem.yaml
+++ b/deployments/tests/pod-inline-2gpu-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-2gpu-mem
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-2gpu-mem
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-2gpu-mem
 ---

--- a/deployments/tests/pod-inline-2gpu.yaml
+++ b/deployments/tests/pod-inline-2gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-2gpu
@@ -7,7 +7,7 @@ spec:
   count: 2
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-2gpu
@@ -19,7 +19,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-2gpu
 ---

--- a/deployments/tests/pod-inline-8vfs-mem.yaml
+++ b/deployments/tests/pod-inline-8vfs-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-8vfs-mem
@@ -8,7 +8,7 @@ spec:
   type: "vf"
   memory: 960
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-8vfs-mem
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-8vfs-mem
 ---

--- a/deployments/tests/pod-inline-8vfs.yaml
+++ b/deployments/tests/pod-inline-8vfs.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-8vfs
@@ -7,7 +7,7 @@ spec:
   count: 8
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-8vfs
@@ -19,7 +19,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-8vfs
 ---

--- a/deployments/tests/pod-inline-gpu-mem.yaml
+++ b/deployments/tests/pod-inline-gpu-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-gpu-mem
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 2048
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-gpu-mem
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-gpu-mem
 ---

--- a/deployments/tests/pod-inline-gpu.yaml
+++ b/deployments/tests/pod-inline-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-gpu
@@ -7,7 +7,7 @@ spec:
   count: 1
   type: "gpu"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-gpu
@@ -19,7 +19,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-gpu
 ---

--- a/deployments/tests/pod-inline-mem.yaml
+++ b/deployments/tests/pod-inline-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-gpu-mem
@@ -8,7 +8,7 @@ spec:
   type: "gpu"
   memory: 512
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-gpu-mem
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-gpu-mem
 ---

--- a/deployments/tests/pod-inline-vf-mem.yaml
+++ b/deployments/tests/pod-inline-vf-mem.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-vf-mem
@@ -8,7 +8,7 @@ spec:
   type: "vf"
   memory: 1024
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-vf-mem
@@ -20,7 +20,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-vf-mem
 ---

--- a/deployments/tests/pod-inline-vf.yaml
+++ b/deployments/tests/pod-inline-vf.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpu.dra.intel.com/v1alpha
+apiVersion: gpu.resource.intel.com/v1alpha2
 kind: GpuClaimParameters
 metadata:
   name: delayed-pod-inline-vf
@@ -7,7 +7,7 @@ spec:
   count: 1
   type: "vf"
 ---
-apiVersion: resource.k8s.io/v1alpha1
+apiVersion: resource.k8s.io/v1alpha2
 kind: ResourceClaimTemplate
 metadata:
   name: delayed-pod-inline-vf
@@ -19,7 +19,7 @@ spec:
   spec:
     resourceClassName: intel-gpu
     parametersRef:
-      apiGroup: gpu.dra.intel.com/v1alpha
+      apiGroup: gpu.resource.intel.com/v1alpha2
       kind: GpuClaimParameters
       name: delayed-pod-inline-vf
 ---


### PR DESCRIPTION
Update `apiVersion` in the examples to align with current iplementation:
* gpu.dra.intel.com/v1alpha changed to gpu.resource.intel.com/v1alpha2
* resource.k8s.io/v1alpha1 to resource.k8s.io/v1alpha2