### PR TITLE
Add model details for A40/A50 and Raptor Lake-P

### DIFF
--- a/pkg/gpu/device/device.go
+++ b/pkg/gpu/device/device.go
@@ -78,6 +78,10 @@ var ModelDetails = map[string]map[string]string{
 		"model":  "A580",
 		"family": "Arc",
 	},
+	"0x56b1": {
+		"model":  "A40/A50",
+		"family": "Arc Pro",
+	},
 	"0x56c0": {
 		"model":  "Flex 170",
 		"family": "Data Center Flex",
@@ -113,6 +117,10 @@ var ModelDetails = map[string]map[string]string{
 	"0x0bdb": {
 		"model":  "Max 1100",
 		"family": "Data Center Max",
+	},
+	"0xa7a0": {
+		"model":  "Raptor Lake-P",
+		"family": "Iris Xe",
 	},
 }
 


### PR DESCRIPTION
Names and formatting pulled from https://admin.pci-ids.ucw.cz/read/PC/8086/56B1 and https://admin.pci-ids.ucw.cz/read/PC/8086/A7A0. These match up with the i915 driver [here](https://github.com/torvalds/linux/blob/2c4a1f3fe03edab80db66688360685031802160a/include/drm/intel/pciids.h), as well as what shows up on some of my systems.