### PR TITLE
Add PCI device ID and address to resource attributes

### DIFF
--- a/cmd/kubelet-gpu-plugin/node_state.go
+++ b/cmd/kubelet-gpu-plugin/node_state.go
@@ -112,10 +112,10 @@ func (s *nodeState) GetResources() kubeletplugin.Resources {
 					"family": {
 						StringValue: &gpu.FamilyName,
 					},
-					"pci-device-id": {
+					"pciId": {
 						StringValue: &gpu.Model,
 					},
-					"pci-device-address": {
+					"pciAddress": {
 						StringValue: &gpu.PCIAddress,
 					},
 				},

--- a/cmd/kubelet-gpu-plugin/node_state.go
+++ b/cmd/kubelet-gpu-plugin/node_state.go
@@ -112,6 +112,12 @@ func (s *nodeState) GetResources() kubeletplugin.Resources {
 					"family": {
 						StringValue: &gpu.FamilyName,
 					},
+					"pci-device-id": {
+						StringValue: &gpu.Model,
+					},
+					"pci-device-address": {
+						StringValue: &gpu.PCIAddress,
+					},
 				},
 				Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
 					"memory":     {Value: resource.MustParse(fmt.Sprintf("%vMi", gpu.MemoryMiB))},


### PR DESCRIPTION
Right now, only "model" and "family" fields are available as device attributes for resource claim selection. When the driver populates these with "Unknown" (which occurs when [this field](https://github.com/intel/intel-resource-drivers-for-kubernetes/blob/ef6d190133b6b8bc13172f4f1bb5575ae15b5aa5/pkg/gpu/device/device.go#L68) is missing an entry for the device ID), there is not enough information to tell the device plugin which device to use.

This adds the PCI device ID and address, which allows for selecting semi-specific models of cards even when the model and family names have not been added to the driver.