### PR TITLE
gpu: remove CDI spec when its last device is removed

### DIFF
--- a/pkg/gpu/cdihelpers/cdihelpers.go
+++ b/pkg/gpu/cdihelpers/cdihelpers.go
@@ -38,7 +38,7 @@ const (
 )
 
 // specName returns the spec name RemoveSpec expects (without extension), not
-// the full file path. Example: /var/run/cdi/intel.com_gpu.yaml -> intel.com_gpu
+// the full file path. Example: /var/run/cdi/intel.com_gpu.yaml -> intel.com_gpu .
 func specName(spec *cdiapi.Spec) string {
 	return strings.TrimSuffix(filepath.Base(spec.GetPath()), filepath.Ext(spec.GetPath()))
 }

--- a/pkg/gpu/cdihelpers/cdihelpers.go
+++ b/pkg/gpu/cdihelpers/cdihelpers.go
@@ -37,6 +37,12 @@ const (
 	containerDevVFIOPath = "/dev/vfio"
 )
 
+// specName returns the spec name RemoveSpec expects (without extension), not
+// the full file path. Example: /var/run/cdi/intel.com_gpu.yaml -> intel.com_gpu
+func specName(spec *cdiapi.Spec) string {
+	return strings.TrimSuffix(filepath.Base(spec.GetPath()), filepath.Ext(spec.GetPath()))
+}
+
 func getGPUSpecs(cdiCache *cdiapi.Cache) []*cdiapi.Spec {
 	gpuSpecs := []*cdiapi.Spec{}
 	for _, cdiSpec := range cdiCache.GetVendorSpecs(device.CDIVendor) {
@@ -59,10 +65,7 @@ func getMEISpecs(cdiCache *cdiapi.Cache) []*cdiapi.Spec {
 
 func replaceGPUCDISpecs(cdiCache *cdiapi.Cache, devices device.DevicesInfo) error {
 	for _, spec := range getGPUSpecs(cdiCache) {
-		// RemoveSpec expects spec name (without extension), not full file path.
-		// Example: /var/run/cdi/intel.com_gpu.yaml -> intel.com_gpu
-		specName := strings.TrimSuffix(filepath.Base(spec.GetPath()), filepath.Ext(spec.GetPath()))
-		if err := cdiCache.RemoveSpec(specName); err != nil {
+		if err := cdiCache.RemoveSpec(specName(spec)); err != nil {
 			return fmt.Errorf("failed to remove old GPU CDI spec %v: %v", spec, err)
 		}
 	}
@@ -80,10 +83,7 @@ func replaceGPUCDISpecs(cdiCache *cdiapi.Cache, devices device.DevicesInfo) erro
 
 func replaceMEICDISpecs(cdiCache *cdiapi.Cache, devices device.DevicesInfo) error {
 	for _, spec := range getMEISpecs(cdiCache) {
-		// RemoveSpec expects spec name (without extension), not full file path.
-		// Example: /var/run/cdi/intel.com_gpu-mei.yaml -> intel.com_gpu-mei.yaml -> intel.com_gpu-mei
-		specName := strings.TrimSuffix(filepath.Base(spec.GetPath()), filepath.Ext(spec.GetPath()))
-		if err := cdiCache.RemoveSpec(specName); err != nil {
+		if err := cdiCache.RemoveSpec(specName(spec)); err != nil {
 			return fmt.Errorf("failed to remove old MEI CDI spec %v: %v", spec, err)
 		}
 	}
@@ -321,13 +321,14 @@ func RemoveDevices(cdiCache *cdiapi.Cache, devicesToRemove []string) error {
 			// reachable on single-GPU hosts: binding the only GPU to a VFIO
 			// driver drops its DRM nodes, emptying the spec.
 			if len(spec.Devices) == 0 {
-				specName := strings.TrimSuffix(filepath.Base(spec.GetPath()), filepath.Ext(spec.GetPath()))
-				if err := cdiCache.RemoveSpec(specName); err != nil {
-					return fmt.Errorf("failed to remove empty CDI spec %v: %v", specName, err)
+				name := specName(spec)
+				if err := cdiCache.RemoveSpec(name); err != nil {
+					return fmt.Errorf("failed to remove empty CDI spec %v: %v", name, err)
 				}
 				continue
 			}
 
+			// WriteSpec, unlike RemoveSpec, expects the file name with extension.
 			specname := path.Base(spec.GetPath())
 			if err := cdiCache.WriteSpec(spec.Spec, specname); err != nil {
 				return fmt.Errorf("failed to write CDI spec %v: %v", specname, err)

--- a/pkg/gpu/cdihelpers/cdihelpers.go
+++ b/pkg/gpu/cdihelpers/cdihelpers.go
@@ -316,6 +316,18 @@ func RemoveDevices(cdiCache *cdiapi.Cache, devicesToRemove []string) error {
 			}
 			spec.Devices = remainingDevices
 
+			// CDI rejects a spec with no devices, so removing the last device
+			// has to delete the spec rather than write it back empty. This is
+			// reachable on single-GPU hosts: binding the only GPU to a VFIO
+			// driver drops its DRM nodes, emptying the spec.
+			if len(spec.Devices) == 0 {
+				specName := strings.TrimSuffix(filepath.Base(spec.GetPath()), filepath.Ext(spec.GetPath()))
+				if err := cdiCache.RemoveSpec(specName); err != nil {
+					return fmt.Errorf("failed to remove empty CDI spec %v: %v", specName, err)
+				}
+				continue
+			}
+
 			specname := path.Base(spec.GetPath())
 			if err := cdiCache.WriteSpec(spec.Spec, specname); err != nil {
 				return fmt.Errorf("failed to write CDI spec %v: %v", specname, err)

--- a/pkg/gpu/cdihelpers/cdihelpers_test.go
+++ b/pkg/gpu/cdihelpers/cdihelpers_test.go
@@ -374,6 +374,48 @@ func TestUpdateGPUDevices(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Single-GPU host: rebinding the only GPU to a VFIO driver drops its
+			// DRM nodes, so removing the old entry empties the spec. CDI rejects
+			// a spec with no devices, so the spec has to be deleted rather than
+			// written back empty.
+			name: "Existing spec, updating the only device empties the spec",
+			existingSpecs: []*cdiapi.Spec{
+				{
+					Spec: &specs.Spec{
+						Kind:    device.CDIKind,
+						Version: "0.6.0",
+						Devices: []specs.Device{
+							{
+								Name: "gpu1",
+								ContainerEdits: specs.ContainerEdits{
+									DeviceNodes: []*specs.DeviceNode{
+										{Path: "/dev/dri/card0", HostPath: "/dev/dri/card0", Type: "c"},
+										{Path: "/dev/dri/renderD128", HostPath: "/dev/dri/renderD128", Type: "c"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			detectedDevices: []*device.DeviceInfo{
+				{UID: "gpu1", VFIODevice: "vfio0", IOMMUGroup: "15", Driver: "xe", CurrentDriver: "xe-vfio-pci"},
+			},
+			expectedError: false,
+			expectedCDIDevices: []specs.Device{
+				{
+					Name: "gpu1",
+					ContainerEdits: specs.ContainerEdits{
+						DeviceNodes: []*specs.DeviceNode{
+							{Path: "/dev/vfio/15", HostPath: "/dev/vfio/15", Type: "c"},
+							{Path: "/dev/vfio/vfio", HostPath: "/dev/vfio/vfio", Type: "c"},
+							{Path: "/dev/vfio/devices/vfio0", HostPath: "/dev/vfio/devices/vfio0", Type: "c"},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #84.

`RemoveDevices` wrote the CDI spec back unconditionally, but CDI rejects a spec with no devices. On a single-GPU host, binding the only GPU to a VFIO driver removes its DRM nodes, so dropping that device empties the spec and the write fails:

```
failed to write CDI spec intel.com-gpu.yaml: invalid CDI Spec: invalid spec, no devices
```

Prepare then aborts, the stale entry is never removed, and containerd fails to stat the absent `/dev/dri/card0`, leaving the device stranded on `vfio-pci`.

This removes the spec when its last device goes, matching what `replaceGPUCDISpecs` already does; `AddGPUDevice` recreates it on the next add. The package's own `writeSpec` helper already guards `len(spec.Devices) == 0`, so this brings `RemoveDevices` in line with it.

### Testing

Added a `TestUpdateGPUDevices` case with one device instead of two. Without the fix it reproduces the failure exactly; with it, the whole package passes.

Also validated on hardware: a single-GPU host (Arc Pro B60, `8086:e211`) now cycles both directions — `gpu-vfio.intel.com` claim rebinds to `vfio-pci` and injects `/dev/vfio/*`, then a `gpu.intel.com` claim rebinds back to `xe` and injects `card0`/`renderD128`. The reverse direction hits the same empty-spec transition, so both paths are covered. Kubernetes v1.36.3, KubeVirt v1.9.0.
